### PR TITLE
Fix an error in setting initial tcp transformation

### DIFF
--- a/python_client/mySock.py
+++ b/python_client/mySock.py
@@ -57,7 +57,7 @@ class mySock:
             # self.buff.truncate(0)
             #print(command)
             try:
-                self.send(command)
+                self.send(daMessage)
                 returnAckNack=self.receive()
                 #print(returnAckNack)
                 if returnAckNack.find('done')==-1:

--- a/python_client/mySock.py
+++ b/python_client/mySock.py
@@ -74,7 +74,7 @@ class mySock:
     def receive(self):
         daBytes=self.sock.recv(1024)
         confirmationMessage=daBytes.decode('utf-8')
-        return confirmationMessage;
+        return confirmationMessage
         
 
         


### PR DESCRIPTION
Hi, @Modi1987!

First, thank you for your excellent work!

When I was using your `iiwaPy3` package, I found that in `mySock.py`, there is a compilation error. The code seems to use an undeclared value `command`. I think that it might be the value `daMessage`. By changing that in the code, I found that the tcp transformation initialization works on my robot.
